### PR TITLE
10.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js: 10
 cache: yarn
 scripts:
   - yarn test
-  - yarn build
+  - tsc && node dist && prettier --write 'lib/**/*.{js,svelte}' 'docs/*.md'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
-node_js: 10
+node_js: 12
 cache: yarn
 scripts:
   - yarn test
-  - tsc && node dist && prettier --write 'lib/**/*.{js,svelte}' 'docs/*.md'
+  - yarn prepack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.10.0](https://github.com/IBM/carbon-pictograms-svelte/releases/tag/v10.10.0) - 2020-04-17
+
+- Bump `@carbon/pictograms` build dependency to 10.10.0
+
+- Use recursive `fs.rmdirSync` (requires Node.js version >=12)
+
+- Run build script in Travis CI
+
 ## [10.9.2](https://github.com/IBM/carbon-pictograms-svelte/releases/tag/v10.9.2) - 2020-04-06
 
 - Initial release (using `@carbon/pictograms@10.9.2`, `@carbon/icon-helpers@10.6.0`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-For MacOS, prerequisites include [homebrew](https://docs.brew.sh/Installation), [node](https://nodejs.org/en/download/package-manager/#macos) and [yarn](https://yarnpkg.com/en/docs/install#mac-stable).
+For MacOS, prerequisites include [homebrew](https://docs.brew.sh/Installation), [node (version >=12)](https://nodejs.org/en/download/package-manager/#macos) and [yarn](https://yarnpkg.com/en/docs/install#mac-stable).
 
 Run the following shell commands to install all three prerequisites.
 
@@ -18,13 +18,13 @@ Fork the repo and clone your fork:
 
 ```bash
 git clone <YOUR_FORK>
-cd carbon-icons-svelte
+cd carbon-pictograms-svelte
 ```
 
 Set the original repo as the upstream:
 
 ```bash
-git remote add upstream git@github.com:IBM/carbon-icons-svelte.git
+git remote add upstream git@github.com:IBM/carbon-pictograms-svelte.git
 # verify that the upstream is added
 git remote -v
 ```
@@ -43,11 +43,11 @@ Run `yarn develop` to run and watch the `src` directory.
 
 ### Building
 
-When building, run `yarn build`.
+Run `yarn prepack` to build the library.
 
-First, the library is transpiled to JavaScript in the `dist` folder.
+First, the library from `src` is transpiled to JavaScript in the `dist` folder.
 
-Then, execute the code by running `node dist`.
+Then, the transpiled code is executed which generates the `lib` folder.
 
 ## Submitting a Pull Request
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # docs
 
-> 458 pictograms total.
+> 482 pictograms total.
 
 ## Usage
 
@@ -52,6 +52,7 @@
 - BerlinTower
 - Bicycle
 - Blockchain
+- BoxPlot
 - Build
 - Building
 - Bulldozer
@@ -64,14 +65,28 @@
 - Capitol
 - Care
 - Cell
+- Chart_3D
+- ChartArea
 - ChartBar
 - ChartBubbleLine
+- ChartBubble
+- ChartCandlestick
+- ChartErrorBar
+- ChartEvaluation
+- ChartHighLow
+- ChartHistogram
 - ChartLine
+- ChartMultiLine
+- ChartParallel
+- ChartRadar
+- ChartRiver
 - ChartScatterplot
+- ChartTSne
 - Cherries
 - ChipCircuit
 - ChipCredit
 - ChipDebit
+- CirclePacking
 - CloudAnalytics
 - CloudAssets
 - CloudBuilderProfessionalServices
@@ -205,6 +220,7 @@
 - HeartHealth
 - Heart
 - HeatMap
+- HeatMap_02
 - HighFive
 - HomeFront
 - HomeGarage
@@ -260,6 +276,7 @@
 - Magnify
 - Marketplace
 - Mas
+- MathCurve
 - Maximize
 - MedicalCharts
 - MedicalStaff
@@ -320,6 +337,7 @@
 - Pills
 - Podcast
 - Police
+- PopulationDiagram
 - Power
 - Presentation
 - Presenter
@@ -331,6 +349,7 @@
 - PrivateNetwork
 - Progress
 - Puzzle
+- QQPlot
 - QuestionAndAnswer
 - Question
 - RainyHeavy
@@ -341,6 +360,7 @@
 - Refinery
 - Refresh
 - RelationshipExtraction
+- RelationshipDiagram
 - RenewTeam
 - Renew
 - Repeat
@@ -361,6 +381,7 @@
 - SatelliteDish
 - Satellite
 - Scale
+- ScatterMatrix
 - Seattle
 - SecureData
 - SecureProfile
@@ -432,6 +453,8 @@
 - Train
 - Transform
 - Trash
+- TreeDiagram
+- TreeMap
 - University
 - UnlockAlt
 - Unlock
@@ -467,6 +490,7 @@
 - Wine
 - WirelessHome
 - WirelessModem
+- WordCloud
 - WreckingBall
 - Yoga_01
 - Yoga_02

--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   "svelte": "lib/index.js",
   "main": "lib/index.js",
   "sideEffects": false,
+  "engines": {
+    "node": ">=12"
+  },
   "scripts": {
     "develop": "tsnd --respawn src",
     "test": "ts-node node_modules/tape/bin/tape src/**.test.ts",
-    "build": "tsc",
-    "prepublishOnly": "tsc && node dist && prettier --write 'lib/**/*.{js,svelte}' 'docs/*.md'"
+    "prepack": "tsc && node dist && prettier --write 'lib/**/*.{js,svelte}' 'docs/*.md'"
   },
   "devDependencies": {
     "@carbon/icon-helpers": "10.6.0",
-    "@carbon/pictograms": "10.9.2",
+    "@carbon/pictograms": "10.10.0",
     "@types/carbon__icon-helpers": "10.6.0",
-    "@types/fs-extra": "^8.1.0",
     "@types/node": "^13.11.0",
     "@types/tape": "^4.2.34",
-    "fs-extra": "^9.0.0",
     "prettier": "1.19.1",
     "prettier-plugin-svelte": "0.7.0",
     "svelte": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-pictograms-svelte",
-  "version": "10.9.2",
+  "version": "10.10.0",
   "license": "Apache-2.0",
   "description": "Svelte components for pictograms in digital and software products using the Carbon Design System",
   "author": "Eric Liu (https://github.com/metonym)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, removeSync, mkdirSync } from "fs-extra";
+import { readFileSync, writeFileSync, rmdirSync, mkdirSync } from "fs";
 import { BuildIcons } from "@carbon/pictograms";
 import { template } from "./template";
 
@@ -7,7 +7,7 @@ function build() {
   const buildInfo: BuildIcons = JSON.parse(source);
   const metadata = { total: buildInfo.length };
 
-  removeSync("lib");
+  rmdirSync("lib", { recursive: true });
   mkdirSync("lib");
 
   const pictograms: string[] = [];
@@ -31,7 +31,7 @@ function build() {
   writeFileSync("lib/index.js", imports.join(""));
   process.stdout.write(JSON.stringify(metadata, null, 2) + "\n");
 
-  removeSync("docs");
+  rmdirSync("docs", { recursive: true });
   mkdirSync("docs");
 
   const docs = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,22 +7,15 @@
   resolved "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.6.0.tgz#72a5bbd1edbee3728e47fa6d17c2aca67dbb101c"
   integrity sha512-4Nh6l+B8SRNyw1RpgNT4Z83Aa5UwRFmKJ2mx5m7mE5TqxPkfIZjyyLHyv5gl3gPtaVwq78ZGz80wG0NRQzRM7g==
 
-"@carbon/pictograms@10.9.2":
-  version "10.9.2"
-  resolved "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-10.9.2.tgz#2139a6bc6b803f26980d20fa99a5ac19f2c8c5fe"
-  integrity sha512-Eo6ToohQrz/WSwxptOmy0X9CBVsQ6pkwA3Clsv4/qW3f+tVNDq4YaC9UiRqF6pTTRXFwVhkHVa27oAeKwovxEA==
+"@carbon/pictograms@10.10.0":
+  version "10.10.0"
+  resolved "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-10.10.0.tgz#d2e5cc7a8cd7931ed73b48accdae3e08633cb675"
+  integrity sha512-VQ/y1U/h5iMMikjE8UZOmLn17roluLeiKGU0jB1LkOAWg82Y+HbzemT8ilHtFm3b3F7cNlUt/auu4edPAcfnrA==
 
 "@types/carbon__icon-helpers@10.6.0":
   version "10.6.0"
   resolved "https://registry.npmjs.org/@types/carbon__icon-helpers/-/carbon__icon-helpers-10.6.0.tgz#dea8ab118b43224235cac793d7967009135e73d4"
   integrity sha512-B1b2PQMSJaNCAWSUsE/RFu45pu2o1nbCyA9TZil70/UQtpB7qQ6aoNQgPSVe7h12+AjNjMf3jZSVZVzGS19o9w==
-
-"@types/fs-extra@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
-  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
-  dependencies:
-    "@types/node" "*"
 
 "@types/node@*", "@types/node@^13.11.0":
   version "13.11.0"
@@ -55,11 +48,6 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
-
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -220,16 +208,6 @@ for-each@~0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-fs-extra@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
-  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -257,7 +235,7 @@ glob@^7.1.3, glob@~7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -357,15 +335,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-jsonfile@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
-  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
-  dependencies:
-    universalify "^1.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -833,11 +802,6 @@ typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-universalify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
-  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
- Bump `@carbon/pictograms` build dependency to 10.10.0
- Use recursive `fs.rmdirSync` (requires Node.js version >=12)
- Run build script in Travis CI