### PR TITLE
bump @carbon/pictograms to 10.16

### DIFF
--- a/PICTOGRAM_INDEX.md
+++ b/PICTOGRAM_INDEX.md
@@ -1,6 +1,6 @@
 # Pictogram Index
 
-> 598 pictograms from @carbon/pictograms@10.15.0
+> 600 pictograms from @carbon/pictograms@10.16.0
 
 ## Usage
 
@@ -287,7 +287,9 @@
 - Hurricane
 - HybridCloud
 - HybridCloudServices
+- IbmCloud
 - IbmIx
+- IbmWatson
 - IbmZ
 - IdBadge
 - Idea

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@carbon/icon-helpers": "10.9.0",
-    "@carbon/pictograms": "10.15.0",
+    "@carbon/pictograms": "10.16.0",
     "@types/carbon__icon-helpers": "10.7.0",
     "@types/node": "^14.0.24",
     "ts-node-dev": "1.0.0-pre.50",

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,9 @@ const usage = [
     /** @type {{}} [default] */
     default?: {};
   };
+
+  /** stub 'on:event' directive as any */
+  $on(eventname: string, handler: (e: Event) => any): () => void;
 }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.9.0.tgz#5aee08e9d253d3bf6f996bc61f739660c62cbb21"
   integrity sha512-JtmCXV7iIc+N5RqQQy+MGT8T+5KcF7+BUKADvHnJKZ8o+ncF5gI4hmrP450dQD76mikI4fqQ0dQflaosesdSPw==
 
-"@carbon/pictograms@10.15.0":
-  version "10.15.0"
-  resolved "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-10.15.0.tgz#a3a09505fb75e0db5eea01e386b143c406fb9e79"
-  integrity sha512-dUyNmcWYwvoPp5qIFO5E8rbAKhrVOpDVUbvmeJPv00XDWnSFdqiTbJ8YOMlFCqfA064cW5zIzX9t3zZz8TsXpg==
+"@carbon/pictograms@10.16.0":
+  version "10.16.0"
+  resolved "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-10.16.0.tgz#395d3642b22b6b12f43959158fb8e07d60c54f6d"
+  integrity sha512-WyAkmw7yd8ZVjBVO0ybKAWQFB0UndgEBcsPdOYqgT9Q8smMRMy09zOZiZdXdTAqVFNGOq5UjfSjXj8ZHsz9h+Q==
 
 "@types/carbon__icon-helpers@10.7.0":
   version "10.7.0"


### PR DESCRIPTION
- fix types: stub `on:eventname` directive for pictogram interface